### PR TITLE
Update Configuration indicating that ws_coliposte_letter_service is required

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('ws_coliposte_letter_service')
+                    ->isRequired()
                     ->children()
                         ->scalarNode('contract_number')->isRequired(true)->cannotBeEmpty()->end()
                         ->scalarNode('password')->isRequired(true)->cannotBeEmpty()->end()


### PR DESCRIPTION
Update configuration to indicate that `lexik_colissimo.ws_coliposte_letter_service` node is required (..because it is) fixing at the same time container exception when not set :

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                        
  Notice: Undefined index: ws_coliposte_letter_service in vendor/lexik/colissimo-bundle/Lexik/Bundle/Coliss  
  imoBundle/DependencyInjection/LexikColissimoExtension.php line 28
```
